### PR TITLE
feat: 도전과제 및 칭호 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencyManagement {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 
 	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/com/example/team2_be/album/Album.java
+++ b/src/main/java/com/example/team2_be/album/Album.java
@@ -33,8 +33,7 @@ public class Album {
     private LocalDateTime createAt;
 
     @Builder
-    public Album (Long id, String albumName, String description, String image, Category category, LocalDateTime createAt){
-        this.id= id;
+    public Album (String albumName, String description, String image, Category category, LocalDateTime createAt){
         this.albumName=albumName;
         this.description=description;
         this.image=image;

--- a/src/main/java/com/example/team2_be/core/error/exception/ApiException.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/ApiException.java
@@ -1,0 +1,19 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+
+public class ApiException extends RuntimeException{
+
+    public ApiException(String message){
+        super(message);
+    }
+
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    public ApiUtils.ApiResult<?> getBody() {
+        return ApiUtils.error(getMessage(), getStatus());
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
@@ -6,17 +6,13 @@ import org.springframework.http.HttpStatus;
 
 
 @Getter
-public class Exception400 extends RuntimeException {
-
+public class Exception400 extends ApiException {
     public Exception400(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
@@ -1,0 +1,22 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+public class Exception400 extends RuntimeException {
+
+    public Exception400(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
@@ -1,0 +1,21 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 인증 안됨
+@Getter
+public class Exception401 extends RuntimeException {
+    public Exception401(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
@@ -6,16 +6,13 @@ import org.springframework.http.HttpStatus;
 
 // 인증 안됨
 @Getter
-public class Exception401 extends RuntimeException {
+public class Exception401 extends ApiException {
     public Exception401(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.UNAUTHORIZED;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
@@ -1,0 +1,20 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception403 extends RuntimeException {
+    public Exception403(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.FORBIDDEN;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class Exception403 extends RuntimeException {
+public class Exception403 extends ApiException{
+
     public Exception403(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.FORBIDDEN;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
@@ -1,0 +1,20 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception404 extends RuntimeException {
+    public Exception404(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class Exception404 extends RuntimeException {
+public class Exception404 extends ApiException{
+
     public Exception404(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.NOT_FOUND);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.NOT_FOUND;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception405.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception405.java
@@ -1,0 +1,14 @@
+package com.example.team2_be.core.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class Exception405 extends ApiException{
+    public Exception405(String message) {
+        super(message);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.METHOD_NOT_ALLOWED;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception500.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception500.java
@@ -1,0 +1,16 @@
+package com.example.team2_be.core.error.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception500 extends ApiException {
+    public Exception500(String message) {
+        super(message);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<?> handleApiException(ApiException e){
+        return new ResponseEntity<>(e.getBody(), e.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleUnknownServerError(Exception e) {
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(),
+                HttpStatus.INTERNAL_SERVER_ERROR);
+
+        //error 테이블을 생성하고 의도치 않은 에러에 대해 관리할 필요가 있음.
+
+        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/example/team2_be/reward/Reward.java
+++ b/src/main/java/com/example/team2_be/reward/Reward.java
@@ -1,0 +1,39 @@
+package com.example.team2_be.reward;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Entity
+@Table
+@Getter
+@ToString
+@NoArgsConstructor
+public class Reward {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 128, nullable = false)
+    private String rewardName;
+
+    @Column(length = 256, nullable = false)
+    private String description;
+
+    @Column(length = 16, nullable = false)
+    private String level;
+
+    @Column(nullable = false)
+    private int goalCount;
+
+    @Builder
+    public Reward(Long id, String rewardName, String description, String level, int goalCount) {
+        this.id = id;
+        this.rewardName = rewardName;
+        this.description = description;
+        this.level = level;
+        this.goalCount = goalCount;
+    }
+}

--- a/src/main/java/com/example/team2_be/reward/Reward.java
+++ b/src/main/java/com/example/team2_be/reward/Reward.java
@@ -1,6 +1,5 @@
 package com.example.team2_be.reward;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -27,13 +26,4 @@ public class Reward {
 
     @Column(nullable = false)
     private int goalCount;
-
-    @Builder
-    public Reward(Long id, String rewardName, String description, String level, int goalCount) {
-        this.id = id;
-        this.rewardName = rewardName;
-        this.description = description;
-        this.level = level;
-        this.goalCount = goalCount;
-    }
 }

--- a/src/main/java/com/example/team2_be/reward/RewardJPARepository.java
+++ b/src/main/java/com/example/team2_be/reward/RewardJPARepository.java
@@ -1,0 +1,6 @@
+package com.example.team2_be.reward;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RewardJPARepository extends JpaRepository<Reward, Long> {
+}

--- a/src/main/java/com/example/team2_be/reward/progress/Progress.java
+++ b/src/main/java/com/example/team2_be/reward/progress/Progress.java
@@ -33,8 +33,7 @@ public class Progress {
     private Reward reward;
 
     @Builder
-    public Progress(Long id, char success, User user, Reward reward) {
-        this.id = id;
+    public Progress(char success, User user, Reward reward) {
         this.count = 0;
         this.success = success;
         this.user = user;

--- a/src/main/java/com/example/team2_be/reward/progress/Progress.java
+++ b/src/main/java/com/example/team2_be/reward/progress/Progress.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/example/team2_be/reward/progress/Progress.java
+++ b/src/main/java/com/example/team2_be/reward/progress/Progress.java
@@ -1,0 +1,44 @@
+package com.example.team2_be.reward.progress;
+
+import com.example.team2_be.reward.Reward;
+import com.example.team2_be.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+
+@Entity
+@Table
+@Getter
+@ToString
+@NoArgsConstructor
+public class Progress {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int count;
+
+    @Column(length = 1, nullable = false)
+    private char success;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reward_id")
+    private Reward reward;
+
+    @Builder
+    public Progress(Long id, char success, User user, Reward reward) {
+        this.id = id;
+        this.count = 0;
+        this.success = success;
+        this.user = user;
+        this.reward = reward;
+    }
+}

--- a/src/main/java/com/example/team2_be/reward/progress/ProgressJPARepository.java
+++ b/src/main/java/com/example/team2_be/reward/progress/ProgressJPARepository.java
@@ -1,6 +1,12 @@
 package com.example.team2_be.reward.progress;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProgressJPARepository extends JpaRepository<Progress, Long> {
+    @Query("select p from Progress p where p.user.id = :id")
+    List<Progress> findByUserId(@Param("id") Long id);
 }

--- a/src/main/java/com/example/team2_be/reward/progress/ProgressJPARepository.java
+++ b/src/main/java/com/example/team2_be/reward/progress/ProgressJPARepository.java
@@ -1,0 +1,6 @@
+package com.example.team2_be.reward.progress;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProgressJPARepository extends JpaRepository<Progress, Long> {
+}

--- a/src/main/java/com/example/team2_be/title/Title.java
+++ b/src/main/java/com/example/team2_be/title/Title.java
@@ -1,0 +1,33 @@
+package com.example.team2_be.title;
+
+import com.example.team2_be.reward.Reward;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Entity
+@Table
+@Getter
+@ToString
+@NoArgsConstructor
+public class Title {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 16, nullable = false)
+    private String titleName;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reward_id")
+    private Reward reward;
+
+    @Builder
+    public Title(Long id, String titleName, Reward reward) {
+        this.id = id;
+        this.titleName = titleName;
+        this.reward = reward;
+    }
+}

--- a/src/main/java/com/example/team2_be/title/Title.java
+++ b/src/main/java/com/example/team2_be/title/Title.java
@@ -1,7 +1,6 @@
 package com.example.team2_be.title;
 
 import com.example.team2_be.reward.Reward;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -23,11 +22,4 @@ public class Title {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reward_id")
     private Reward reward;
-
-    @Builder
-    public Title(Long id, String titleName, Reward reward) {
-        this.id = id;
-        this.titleName = titleName;
-        this.reward = reward;
-    }
 }

--- a/src/main/java/com/example/team2_be/title/TitleJPARepository.java
+++ b/src/main/java/com/example/team2_be/title/TitleJPARepository.java
@@ -1,0 +1,6 @@
+package com.example.team2_be.title;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TitleJPARepository extends JpaRepository<Title, Long> {
+}

--- a/src/main/java/com/example/team2_be/title/collection/Collection.java
+++ b/src/main/java/com/example/team2_be/title/collection/Collection.java
@@ -1,0 +1,40 @@
+package com.example.team2_be.title.collection;
+
+import com.example.team2_be.title.Title;
+import com.example.team2_be.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@ToString
+@NoArgsConstructor
+public class Collection {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDateTime creatAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "title_id")
+    private Title title;
+
+    @Builder
+    public Collection(Long id, User user, Title title) {
+        this.id = id;
+        this.creatAt = LocalDateTime.now();
+        this.user = user;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/example/team2_be/title/collection/Collection.java
+++ b/src/main/java/com/example/team2_be/title/collection/Collection.java
@@ -31,8 +31,7 @@ public class Collection {
     private Title title;
 
     @Builder
-    public Collection(Long id, User user, Title title) {
-        this.id = id;
+    public Collection(User user, Title title) {
         this.createAt = LocalDateTime.now();
         this.user = user;
         this.title = title;

--- a/src/main/java/com/example/team2_be/title/collection/Collection.java
+++ b/src/main/java/com/example/team2_be/title/collection/Collection.java
@@ -20,7 +20,7 @@ public class Collection {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime creatAt;
+    private LocalDateTime createAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
@@ -33,7 +33,7 @@ public class Collection {
     @Builder
     public Collection(Long id, User user, Title title) {
         this.id = id;
-        this.creatAt = LocalDateTime.now();
+        this.createAt = LocalDateTime.now();
         this.user = user;
         this.title = title;
     }

--- a/src/main/java/com/example/team2_be/title/collection/CollectionJPARepository.java
+++ b/src/main/java/com/example/team2_be/title/collection/CollectionJPARepository.java
@@ -1,0 +1,12 @@
+package com.example.team2_be.title.collection;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CollectionJPARepository extends JpaRepository<Collection, Long> {
+    @Query("select c from Collection c where c.user.id = :id")
+    List<Collection> findByUserId(@Param("id") Long id);
+}

--- a/src/main/java/com/example/team2_be/user/User.java
+++ b/src/main/java/com/example/team2_be/user/User.java
@@ -1,5 +1,6 @@
 package com.example.team2_be.user;
 
+import com.example.team2_be.title.Title;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,5 +49,9 @@ public class User {
 
     void update(String newNickname) {
         this.nickname = newNickname;
+    }
+
+    void updateTitle(String newTitle) {
+        this.title = newTitle;
     }
 }

--- a/src/main/java/com/example/team2_be/user/User.java
+++ b/src/main/java/com/example/team2_be/user/User.java
@@ -23,6 +23,9 @@ public class User {
     @Column(length = 32, nullable = false, unique = true)
     private String nickname;
 
+    @Column(length = 16)
+    private String title;
+
     @Column(length = 512, nullable = false)
     private String image;
 

--- a/src/main/java/com/example/team2_be/user/UserController.java
+++ b/src/main/java/com/example/team2_be/user/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
 
         return ResponseEntity.ok(ApiUtils.success(rewardFindResponseDTO));
     }
+
+    @GetMapping("/titles")
+    public ResponseEntity<?> findTitle(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserTitleFindResponseDTO titleFindResponseDTO = userService.findUserTitle(userDetails.getUser());
+
+        return ResponseEntity.ok(ApiUtils.success(titleFindResponseDTO));
+    }
 }

--- a/src/main/java/com/example/team2_be/user/UserController.java
+++ b/src/main/java/com/example/team2_be/user/UserController.java
@@ -4,6 +4,8 @@ import com.example.team2_be.core.security.CustomUserDetails;
 import com.example.team2_be.core.utils.ApiUtils;
 import com.example.team2_be.user.dto.UserInfoFindResponseDTO;
 import com.example.team2_be.user.dto.UserInfoUpdateRequestDTO;
+import com.example.team2_be.user.dto.UserRewardFindResponseDTO;
+import com.example.team2_be.user.dto.UserTitleFindResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,5 +29,12 @@ public class UserController {
         userService.updateUserInfo(updateDTO, userDetails.getUser());
 
         return ResponseEntity.ok(null);
+    }
+
+    @GetMapping("/rewards")
+    public ResponseEntity<?> findReward(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserRewardFindResponseDTO rewardFindResponseDTO = userService.findUserReward(userDetails.getUser());
+
+        return ResponseEntity.ok(ApiUtils.success(rewardFindResponseDTO));
     }
 }

--- a/src/main/java/com/example/team2_be/user/UserController.java
+++ b/src/main/java/com/example/team2_be/user/UserController.java
@@ -44,4 +44,11 @@ public class UserController {
 
         return ResponseEntity.ok(ApiUtils.success(titleFindResponseDTO));
     }
+
+    @PutMapping("/titles/{id}")
+    public ResponseEntity<ApiUtils.ApiResult<Object>> updateTitle(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.updateUserTitle(id, userDetails.getUser());
+
+        return ResponseEntity.ok(ApiUtils.success(null));
+    }
 }

--- a/src/main/java/com/example/team2_be/user/UserController.java
+++ b/src/main/java/com/example/team2_be/user/UserController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -19,13 +21,13 @@ public class UserController {
 
     @GetMapping("/find")
     public ResponseEntity<?> find(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        UserInfoFindResponseDTO findDTO = userService.findUser(userDetails.getUser());
+        UserInfoFindResponseDTO findDTO = userService.findUserInfo(userDetails.getUser());
 
         return ResponseEntity.ok(ApiUtils.success(findDTO));
     }
 
     @PutMapping("/update")
-    public ResponseEntity<?> update(@RequestBody UserInfoUpdateRequestDTO updateDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> update(@RequestBody @Valid UserInfoUpdateRequestDTO updateDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.updateUserInfo(updateDTO, userDetails.getUser());
 
         return ResponseEntity.ok(null);

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -79,4 +79,11 @@ public class UserService {
 
         return new UserRewardFindResponseDTO(findRewards, findProgresses);
     }
+
+    public UserTitleFindResponseDTO findUserTitle(User user) {
+        User findUser = userJPARepository.findByEmail(user.getEmail());
+        List<Collection> collections = collectionJPARepository.findByUserId(findUser.getId());
+
+        return new UserTitleFindResponseDTO(collections);
+    }
 }

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -55,10 +55,8 @@ public class UserService {
         return newUser;
     }
 
-    public UserInfoFindResponseDTO findUser(User user) {
+    public UserInfoFindResponseDTO findUserInfo(User user) {
         User findUser = userJPARepository.findByEmail(user.getEmail());
-
-        // 예외 처리 : 유저 찾기 실패
 
         return new UserInfoFindResponseDTO(findUser);
     }
@@ -66,8 +64,6 @@ public class UserService {
     @Transactional
     public void updateUserInfo(UserInfoUpdateRequestDTO updateDTO, User user) {
         User findUser = userJPARepository.findByEmail(user.getEmail());
-
-        // 예외 처리 : 본인이 맞는지 권한 체크
 
         findUser.update(updateDTO.getNewNickname());
     }

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -86,4 +86,16 @@ public class UserService {
 
         return new UserTitleFindResponseDTO(collections);
     }
+
+    @Transactional
+    public void updateUserTitle(Long id, User user) {
+        User findUser = userJPARepository.findByEmail(user.getEmail());
+
+        Collection findCollection = collectionJPARepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 칭호를 찾을 수 없음"));
+
+        findUser.updateTitle(findCollection.getTitle().getTitleName());
+
+        System.out.println("findUser = " + findUser);
+    }
 }

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -1,20 +1,32 @@
 package com.example.team2_be.user;
 
 import com.example.team2_be.kakao.dto.KakaoAccount;
+import com.example.team2_be.reward.Reward;
+import com.example.team2_be.reward.RewardJPARepository;
+import com.example.team2_be.reward.progress.Progress;
+import com.example.team2_be.reward.progress.ProgressJPARepository;
+import com.example.team2_be.title.collection.Collection;
+import com.example.team2_be.title.collection.CollectionJPARepository;
 import com.example.team2_be.user.dto.UserInfoFindResponseDTO;
 import com.example.team2_be.user.dto.UserInfoUpdateRequestDTO;
+import com.example.team2_be.user.dto.UserRewardFindResponseDTO;
+import com.example.team2_be.user.dto.UserTitleFindResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
-
     private final UserJPARepository userJPARepository;
+    private final RewardJPARepository rewardJPARepository;
+    private final ProgressJPARepository progressJPARepository;
+    private final CollectionJPARepository collectionJPARepository;
+
     public static final String DEFAULT_IMAGE_URL = "";
 
     @Transactional
@@ -57,5 +69,14 @@ public class UserService {
         // 예외 처리 : 본인이 맞는지 권한 체크
 
         findUser.update(updateDTO.getNewNickname());
+    }
+
+    public UserRewardFindResponseDTO findUserReward(User user) {
+        List<Reward> findRewards = rewardJPARepository.findAll();
+
+        User findUser = userJPARepository.findByEmail(user.getEmail());
+        List<Progress> findProgresses = progressJPARepository.findByUserId(findUser.getId());
+
+        return new UserRewardFindResponseDTO(findRewards, findProgresses);
     }
 }

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -95,7 +95,5 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 칭호를 찾을 수 없음"));
 
         findUser.updateTitle(findCollection.getTitle().getTitleName());
-
-        System.out.println("findUser = " + findUser);
     }
 }

--- a/src/main/java/com/example/team2_be/user/UserService.java
+++ b/src/main/java/com/example/team2_be/user/UserService.java
@@ -1,5 +1,6 @@
 package com.example.team2_be.user;
 
+import com.example.team2_be.core.error.exception.Exception404;
 import com.example.team2_be.kakao.dto.KakaoAccount;
 import com.example.team2_be.reward.Reward;
 import com.example.team2_be.reward.RewardJPARepository;
@@ -92,7 +93,7 @@ public class UserService {
         User findUser = userJPARepository.findByEmail(user.getEmail());
 
         Collection findCollection = collectionJPARepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 칭호를 찾을 수 없음"));
+                .orElseThrow(() -> new Exception404("해당 칭호를 찾을 수 없습니다."));
 
         findUser.updateTitle(findCollection.getTitle().getTitleName());
     }

--- a/src/main/java/com/example/team2_be/user/dto/UserInfoUpdateRequestDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserInfoUpdateRequestDTO.java
@@ -2,8 +2,10 @@ package com.example.team2_be.user.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.Size;
+
 @Getter
 public class UserInfoUpdateRequestDTO {
-    // 요청에 담긴 데이터의 유효성 판별 필요
+    @Size(min = 2, message = "닉네임은 두 글자 이상이어야 합니다.")
     private String newNickname;
 }

--- a/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
@@ -19,3 +19,35 @@ public class UserRewardFindResponseDTO {
                 .collect(Collectors.toList());
     }
 }
+
+@Getter
+class RewardDTO {
+    private Long id;
+    private String rewardName;
+    private String description;
+    private String level;
+    private int goalCount;
+    private int count;
+    private char success;
+
+    public RewardDTO(Reward reward, List<Progress> progresses) {
+        this.id = reward.getId();
+        this.rewardName = reward.getRewardName();
+        this.description = reward.getDescription();
+        this.level = reward.getLevel();
+        this.goalCount = reward.getGoalCount();
+
+        Optional<Progress> findProgress = progresses.stream()
+                .filter(progress -> progress.getReward().getId().equals(reward.getId()))
+                .findFirst();
+
+        Progress thisProgress = new Progress();
+
+        if(findProgress.isPresent()) {
+            thisProgress = findProgress.get();
+        }
+
+        this.count = thisProgress.getCount();
+        this.success = thisProgress.getSuccess();
+    }
+}

--- a/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
@@ -5,7 +5,6 @@ import com.example.team2_be.reward.progress.Progress;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserRewardFindResponseDTO.java
@@ -1,0 +1,21 @@
+package com.example.team2_be.user.dto;
+
+import com.example.team2_be.reward.Reward;
+import com.example.team2_be.reward.progress.Progress;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+public class UserRewardFindResponseDTO {
+    List<RewardDTO> rewards;
+
+    public UserRewardFindResponseDTO(List<Reward> rewards, List<Progress> progresses) {
+        this.rewards = rewards.stream()
+                .map(reward -> new RewardDTO(reward, progresses))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/team2_be/user/dto/UserTitleFindResponseDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserTitleFindResponseDTO.java
@@ -16,3 +16,14 @@ public class UserTitleFindResponseDTO {
                 .collect(Collectors.toList());
     }
 }
+
+@Getter
+class TitleDTO {
+    private Long id;
+    private String titleName;
+
+    public TitleDTO(Collection collection) {
+        this.id = collection.getId();
+        this.titleName = collection.getTitle().getTitleName();
+    }
+}

--- a/src/main/java/com/example/team2_be/user/dto/UserTitleFindResponseDTO.java
+++ b/src/main/java/com/example/team2_be/user/dto/UserTitleFindResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.team2_be.user.dto;
+
+import com.example.team2_be.title.collection.Collection;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class UserTitleFindResponseDTO {
+    private List<TitleDTO> titles;
+
+    public UserTitleFindResponseDTO(List<Collection> collections) {
+        this.titles = collections.stream()
+                .map(TitleDTO::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+      default_batch_fetch_size: 100
+    open-in-view: false
+
+kakao:
+  tokenUrl: https://kauth.kakao.com/oauth/token
+  userApiUrl: https://kapi.kakao.com/v2/user/me
+  restapiKey: 0efff2c2f5f7de603b91cb6230b131ab
+  redirectUrl:  http://localhost:8080/callback
+  authUrl: https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -13,3 +13,5 @@ INSERT INTO users (`id`, `email`, `nickname`, `title`, `image`, `role`, `create_
 INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze');
 INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold');
 
+-- 진행도
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'Y', '1', '2');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -15,3 +15,6 @@ INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) V
 
 -- 진행도
 INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'Y', '1', '2');
+
+-- 칭호
+INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('1', '방문객', '2');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -14,7 +14,9 @@ INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) V
 INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold', '1');
 
 -- 진행도
-INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'Y', '1', '2');
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'N', '1', '1');
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('2', '0', 'Y', '1', '2');
+
 
 -- 칭호
 INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('1', '방문객', '2');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -10,16 +10,21 @@ SET REFERENTIAL_INTEGRITY TRUE;
 INSERT INTO users (`id`, `email`, `nickname`, `title`, `image`, `role`, `create_at`) VALUES ('1', 'admin', 'admin', '내가 관리자라니!!', '이미지', 'ROLE_ADMIN', '2023-08-29 13:54:19.823');
 
 -- 도전과제
-INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze', '1');
-INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold', '1');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '어드민 유저가 뭔데?', '관리자가 되어보세요.', 'challenger', '10000000');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze', '1');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('3', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold', '1');
 
 -- 진행도
-INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'N', '1', '1');
-INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('2', '0', 'Y', '1', '2');
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '10000000', 'Y', '1', '1');
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('2', '0', 'N', '1', '2');
+INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('3', '0', 'Y', '1', '3');
 
 
 -- 칭호
-INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('1', '방문객', '2');
+INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('1', '내가 관리자라니!!', '1');
+INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('2', '추억 앨범 관리자', '2');
+INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('3', '방문객', '3');
 
 -- 칭호 획득
 INSERT INTO collection (`id`, `create_at`, `users_id`, `title_id`) VALUES ('1', '2023-08-29 13:54:19.823', '1', '1');
+INSERT INTO collection (`id`, `create_at`, `users_id`, `title_id`) VALUES ('2', '2023-08-29 13:54:19.823', '1', '3');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,11 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+truncate table users;
+truncate table reward;
+truncate table progress;
+truncate table title;
+truncate table collection;
+SET REFERENTIAL_INTEGRITY TRUE;
+
+-- 유저
+INSERT INTO users (`id`, `email`, `nickname`, `title`, `image`, `role`, `create_at`) VALUES ('1', 'admin', 'admin', '내가 관리자라니!!', '이미지', 'ROLE_ADMIN', '2023-08-29 13:54:19.823');
+

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -10,11 +10,14 @@ SET REFERENTIAL_INTEGRITY TRUE;
 INSERT INTO users (`id`, `email`, `nickname`, `title`, `image`, `role`, `create_at`) VALUES ('1', 'admin', 'admin', '내가 관리자라니!!', '이미지', 'ROLE_ADMIN', '2023-08-29 13:54:19.823');
 
 -- 도전과제
-INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze');
-INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze', '1');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold', '1');
 
 -- 진행도
 INSERT INTO progress (`id`, `count`, `success`, `users_id`, `reward_id`) VALUES ('1', '0', 'Y', '1', '2');
 
 -- 칭호
 INSERT INTO title (`id` , `title_name`, `reward_id`) VALUES ('1', '방문객', '2');
+
+-- 칭호 획득
+INSERT INTO collection (`id`, `create_at`, `users_id`, `title_id`) VALUES ('1', '2023-08-29 13:54:19.823', '1', '1');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -9,3 +9,7 @@ SET REFERENTIAL_INTEGRITY TRUE;
 -- 유저
 INSERT INTO users (`id`, `email`, `nickname`, `title`, `image`, `role`, `create_at`) VALUES ('1', 'admin', 'admin', '내가 관리자라니!!', '이미지', 'ROLE_ADMIN', '2023-08-29 13:54:19.823');
 
+-- 도전과제
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('1', '우리들의 첫번째 추억 기록', '첫번째 앨범 페이지를 생성해보세요.', 'bronze');
+INSERT INTO reward (`id`, `reward_name`, `description`, `level`, `goal_count`) VALUES ('2', '콜롬버스 등장', '네모에 오신 것을 환영합니다.', 'gold');
+

--- a/src/test/java/com/example/team2_be/reward/RewardRepositoryTest.java
+++ b/src/test/java/com/example/team2_be/reward/RewardRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.example.team2_be.reward;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Sql(value = "classpath:import.sql")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(value = {"classpath:application-test.yml"})
+class RewardRepositoryTest {
+    @Autowired
+    RewardJPARepository rewardJPARepository;
+
+    @Test
+    @DisplayName("도전과제 조회 테스트")
+    void find_all_reward_test() {
+        //when
+        List<Reward> rewards = rewardJPARepository.findAll();
+
+        //then
+        assertThat(rewards.isEmpty()).isEqualTo(false);
+    }
+}

--- a/src/test/java/com/example/team2_be/title/TitleRepositoryTest.java
+++ b/src/test/java/com/example/team2_be/title/TitleRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.example.team2_be.title;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Sql(value = "classpath:import.sql")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(value = {"classpath:application-test.yml"})
+class TitleRepositoryTest {
+    @Autowired
+    TitleJPARepository titleJPARepository;
+
+    @Test
+    @DisplayName("칭호 조회 테스트")
+    void find_all_title_test() {
+        //when
+        List<Title> titles = titleJPARepository.findAll();
+
+        //then
+        assertThat(titles.isEmpty()).isEqualTo(false);
+    }
+}

--- a/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
+++ b/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.example.team2_be.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@Sql(value = "classpath:import.sql")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(value = {"classpath:application-test.yml"})
+class UserIntegrationTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("유저의 도전과제 조회 테스트")
+    @WithUserDetails(value = "admin")
+    void find_user_reward_test() throws Exception {
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/users/rewards")
+        );
+
+        //then
+        resultActions.andExpect(jsonPath("$.success").value("true"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
+++ b/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -44,6 +45,23 @@ class UserIntegrationTest {
         //when
         ResultActions resultActions = mockMvc.perform(
                 get("/users/titles")
+        );
+
+        //then
+        resultActions.andExpect(jsonPath("$.success").value("true"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("유저의 칭호 변경 테스트")
+    @WithUserDetails(value = "admin")
+    void update_user_title_test() throws Exception {
+        //given
+        Long id = 2L;
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                put("/users/titles/{id}", id)
         );
 
         //then

--- a/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
+++ b/src/test/java/com/example/team2_be/user/UserIntegrationTest.java
@@ -36,4 +36,18 @@ class UserIntegrationTest {
         resultActions.andExpect(jsonPath("$.success").value("true"))
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("유저의 칭호 조회 테스트")
+    @WithUserDetails(value = "admin")
+    void find_user_title_test() throws Exception {
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/users/titles")
+        );
+
+        //then
+        resultActions.andExpect(jsonPath("$.success").value("true"))
+                .andDo(print());
+    }
 }


### PR DESCRIPTION
# 구현 사항
#17 
1. 도전과제 목록 조회
2. 도전과제에 대한 진행률 조회
3. 유저가 획득한 칭호 목록 조회

# 이슈 사항
1. UserDetailsService가 구현되지 않아 @WithUserDetails를 이용해 통합 테스팅에 어려움이 있었습니다.
- 급한대로 UserDetailsService를 로컬에서만 작성해서 테스트하고 커밋은 하지 않았습니다.
2. jasypt 라이브러리의 디코딩 키가 테스트 환경에서는 적용되지 않는 이슈가 발생하였습니다.
- JwtProvider 클래스에 시크릿 키를 임의로 작성하고 테스트를 진행하였고 커밋은 하지 않았습니다.
3. 엔티티 빌더에 id를 포함하여 id 조작의 여지를 발견하였습니다.
- 해당 PR 에 포함되는 엔티티의 id를 제거하였습니다.
4. 유저 찾기 시 유저가 존재하지 않는 예외 처리에 대해 생각해봐야 합니다.