### PR TITLE
feat: GlobalExceptionHandler를 사용한 에러 핸들링

### DIFF
--- a/src/main/java/com/example/team2_be/core/error/exception/ApiException.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/ApiException.java
@@ -1,0 +1,19 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+
+public class ApiException extends RuntimeException{
+
+    public ApiException(String message){
+        super(message);
+    }
+
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    public ApiUtils.ApiResult<?> getBody() {
+        return ApiUtils.error(getMessage(), getStatus());
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
@@ -6,17 +6,13 @@ import org.springframework.http.HttpStatus;
 
 
 @Getter
-public class Exception400 extends RuntimeException {
-
+public class Exception400 extends ApiException {
     public Exception400(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception400.java
@@ -1,0 +1,22 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+public class Exception400 extends RuntimeException {
+
+    public Exception400(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
@@ -1,0 +1,21 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 인증 안됨
+@Getter
+public class Exception401 extends RuntimeException {
+    public Exception401(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception401.java
@@ -6,16 +6,13 @@ import org.springframework.http.HttpStatus;
 
 // 인증 안됨
 @Getter
-public class Exception401 extends RuntimeException {
+public class Exception401 extends ApiException {
     public Exception401(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.UNAUTHORIZED;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
@@ -1,0 +1,20 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception403 extends RuntimeException {
+    public Exception403(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.FORBIDDEN;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception403.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class Exception403 extends RuntimeException {
+public class Exception403 extends ApiException{
+
     public Exception403(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.FORBIDDEN;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
@@ -1,0 +1,20 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception404 extends RuntimeException {
+    public Exception404(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception404.java
@@ -5,16 +5,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class Exception404 extends RuntimeException {
+public class Exception404 extends ApiException{
+
     public Exception404(String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
-        return ApiUtils.error(getMessage(), HttpStatus.NOT_FOUND);
-    }
-
-    public HttpStatus status(){
+    @Override
+    public HttpStatus getStatus() {
         return HttpStatus.NOT_FOUND;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception405.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception405.java
@@ -1,0 +1,14 @@
+package com.example.team2_be.core.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class Exception405 extends ApiException{
+    public Exception405(String message) {
+        super(message);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.METHOD_NOT_ALLOWED;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/Exception500.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/Exception500.java
@@ -1,0 +1,16 @@
+package com.example.team2_be.core.error.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception500 extends ApiException {
+    public Exception500(String message) {
+        super(message);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.team2_be.core.error.exception;
+
+import com.example.team2_be.core.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<?> handleApiException(ApiException e){
+        return new ResponseEntity<>(e.getBody(), e.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleUnknownServerError(Exception e) {
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(),
+                HttpStatus.INTERNAL_SERVER_ERROR);
+
+        //error 테이블을 생성하고 의도치 않은 에러에 대해 관리할 필요가 있음.
+
+        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## Issue
#19 

Interface로 상위 class를 생성하려고 했지만 @ExceptionHandler가 interface를 인식하지 못하는 상황 발생
따라서 RuntimeException을 상속 받는 상위 class인 ApiException 생성 후 각 Exception class가 상속 받는 형태로 변경

## Description

GlobalExceptionHandler class를 사용하여 exception을 Controller에서 처리하지 않고 DS에게 위임하는 기능

## Tasks
- [x] Exception400 class 생성
- [x] Exception401 class 생성
- [x] Exception403 class 생성
- [x] Exception404 class 생성
- [x] Exception405 class 생성 
- [x] Exception500 class 생성
- [x] Exception class의 상위 ApiException class 생성
- [x] GlobalExceptionHandler class 생성 

## References

<img width="422" alt="KakaoTalk_20231005_171626680" src="https://github.com/Step3-kakao-tech-campus/Team2_BE/assets/101192772/6149b174-6527-48da-a8dc-d0d1a11828d0">
