### PR TITLE
feat: Error DB에 예기치 못한 오류 INSERT 기능

### DIFF
--- a/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
@@ -1,26 +1,53 @@
 package com.example.team2_be.core.error.exception;
 
 import com.example.team2_be.core.utils.ApiUtils;
+import com.example.team2_be.error.Error;
+import com.example.team2_be.error.ErrorJPARepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final ErrorJPARepository errorJPARepository;
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<?> handleApiException(ApiException e){
         return new ResponseEntity<>(e.getBody(), e.getStatus());
     }
 
+    @Transactional
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleUnknownServerError(Exception e) {
         ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(),
                 HttpStatus.INTERNAL_SERVER_ERROR);
 
-        //error 테이블을 생성하고 의도치 않은 에러에 대해 관리할 필요가 있음.
+        Error error = Error.builder()
+                .message(e.getMessage())
+                .stackTrace(filterStackTraceOnException(e).toString())
+                .createAt(LocalDateTime.now())
+                .build();
+        errorJPARepository.save(error);
 
         return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private StringBuilder filterStackTraceOnException(Exception e) {
+        StackTraceElement[] stackTrace = e.getStackTrace();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (StackTraceElement element : stackTrace) {
+            if (element.getClassName().contains("com.example.team2_be")) {
+                stringBuilder.append(element).append("\n");
+            }
+        }
+        return stringBuilder;
     }
 }

--- a/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/team2_be/core/error/exception/GlobalExceptionHandler.java
@@ -29,14 +29,18 @@ public class GlobalExceptionHandler {
         ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(),
                 HttpStatus.INTERNAL_SERVER_ERROR);
 
+        saveError(e);
+
+        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private void saveError(Exception e) {
         Error error = Error.builder()
                 .message(e.getMessage())
                 .stackTrace(filterStackTraceOnException(e).toString())
                 .createAt(LocalDateTime.now())
                 .build();
         errorJPARepository.save(error);
-
-        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     private StringBuilder filterStackTraceOnException(Exception e) {

--- a/src/main/java/com/example/team2_be/error/Error.java
+++ b/src/main/java/com/example/team2_be/error/Error.java
@@ -1,0 +1,29 @@
+package com.example.team2_be.error;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+public class Error {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 4096, nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private int status;
+
+    @Column(length = 1024, nullable = false)
+    private String stackTrace;
+
+    @Column(nullable = false)
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/example/team2_be/error/Error.java
+++ b/src/main/java/com/example/team2_be/error/Error.java
@@ -16,22 +16,18 @@ public class Error {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 4096, nullable = false)
+    @Column(length = 1024, nullable = false)
     private String message;
 
-    @Column(nullable = false)
-    private int status;
-
-    @Column(length = 1024, nullable = false)
+    @Column(length = 4096, nullable = false)
     private String stackTrace;
 
     @Column(nullable = false)
     private LocalDateTime createAt;
 
     @Builder
-    public Error(String message, int status, String stackTrace, LocalDateTime createAt) {
+    public Error(String message, String stackTrace, LocalDateTime createAt) {
         this.message = message;
-        this.status = status;
         this.stackTrace = stackTrace;
         this.createAt = createAt;
     }

--- a/src/main/java/com/example/team2_be/error/Error.java
+++ b/src/main/java/com/example/team2_be/error/Error.java
@@ -1,5 +1,6 @@
 package com.example.team2_be.error;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -26,4 +27,12 @@ public class Error {
 
     @Column(nullable = false)
     private LocalDateTime createAt;
+
+    @Builder
+    public Error(String message, int status, String stackTrace, LocalDateTime createAt) {
+        this.message = message;
+        this.status = status;
+        this.stackTrace = stackTrace;
+        this.createAt = createAt;
+    }
 }

--- a/src/main/java/com/example/team2_be/error/ErrorJPARepository.java
+++ b/src/main/java/com/example/team2_be/error/ErrorJPARepository.java
@@ -1,0 +1,6 @@
+package com.example.team2_be.error;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ErrorJPARepository extends JpaRepository<Error, Long> {
+}


### PR DESCRIPTION
## Issue
#38 

stackTrace가 굉장히 길게 보내질 수 있기 때문에 DB에 Column length 초과 및 오류 확인에 어려움이 있음, 따라서 Error Entity 내 stackTrace field length를 4096으로 변경 후 패키지 내 class와 관련된 stackTrace만 필터링해서 Error DB에 담음

다른 Exception class처럼 status를 설정하지 않고는 status를 받아올 수 있는 메서드가 존재하지 않음, 따라서 직접 status를 설정해주어야 하는데 예기치 못한 오류에 직접 설정하는 것은 불가능하다고 판단해서 status field를 삭제함
(만약 status를 받아올 수 있는 기능을 알고 계신다면 알려주십쇼 (_ _) )

## Description

예기치 못한 오류 발생 시 Error DB에 INSERT하는 기능 개발

## Tasks
- [x] notion에 error db 추가
- [x] Error Entity 생성
- [x] GlobalExceptionHandler에 handleUnknownServerError Method에 Error DB INSERT 코드 추가
